### PR TITLE
v1.0.0 Stable API Release

### DIFF
--- a/Dev/bench.pl
+++ b/Dev/bench.pl
@@ -1,0 +1,80 @@
+use lib './lib';
+use strict;
+use warnings;
+use JavaScript::Duktape;
+use Data::Dumper;
+use Benchmark qw(:all :hireswallclock) ;
+
+my $js  = JavaScript::Duktape->new();
+my $duk = $js->duk;
+
+my $time = 5;
+my $count = 25000;
+
+
+
+{ ##settung global functions
+
+    my $t = timeit($count, sub{
+        $js->set('test', sub{});
+    });
+    print_results("set global functions", $t);
+}
+
+{ ##getting javascript object
+
+    my $t = timeit($count, sub{
+        $duk->eval_string(qq~
+            function javascriptObject1 (){}
+            javascriptObject1;
+        ~);
+
+        my $obj = $duk->to_perl_object(-1);
+        $duk->pop();
+    });
+    print_results("getting objects", $t);
+}
+
+{ ##object operations
+    $duk->eval_string(qq~
+        function javascriptObject (){
+            this.callme = function(n){
+                this.test = n;
+            }
+        }
+        javascriptObject;
+    ~);
+    my $obj = $duk->to_perl_object(-1);
+    $duk->pop();
+
+    { #calling new on objects
+        my $t = timeit($count, sub{
+            my $o = $obj->new();
+        });
+        print_results("calling new", $t);
+    }
+
+    { #calling function from objects
+        my $o = $obj->new();
+        my $i = 0;
+        my $t = timeit($count, sub{
+            $o->callme($i++);
+            # print $o->test, "\n";
+        });
+        print_results("calling function", $t);
+    }
+}
+
+sub print_results {
+    my $name = shift;
+    my $t    = shift;
+
+    my @result = split('@', timestr($t));
+
+    print "===================================\n";
+    print "$count $name\n";
+    print "===================================\n";
+    print " " . $result[0], "\n";
+    print $result[1], "\n";
+    print "\n\n";
+}

--- a/t/objects/01.t
+++ b/t/objects/01.t
@@ -1,0 +1,60 @@
+use strict;
+use warnings;
+use Data::Dumper;
+use lib './lib';
+use JavaScript::Duktape;
+use Test::More;
+
+my $js = JavaScript::Duktape->new();
+my $duk = $js->duk;
+
+$duk->eval_string(qq~
+    var tt = {};
+    tt.all = test;
+    function test (fn){
+        this.name       = 'Mamod';
+        this.lastname   = "Foo";
+        this.counter    = 0;
+        this.test       = function(){
+            this.counter++;
+            fn();
+        };
+    }
+
+    test.prototype.setLast = function(fn){
+        this.lastname = fn;
+        this.fullname = this.name + " " + fn('Mehy');
+    }
+    test;
+~);
+
+my $obj = $duk->to_perl_object(-1);
+$duk->pop();
+
+for (0 .. 100){
+    my $t = $obj->new(sub{});
+    $t->setLast( sub {
+        my $this = shift;
+        my $last = shift . "ar";
+        return $last;
+    });
+    is $t->lastname('Mehy'), "Mehyar";
+    is $t->fullname, "Mamod Mehyar";
+}
+
+my $t = $obj->new(sub {
+    my $this = shift;
+    ok(1);
+});
+
+$t->setLast( sub {
+    my $this = shift;
+    my $last = shift . "ar";
+    $this->test("");
+    return $last;
+});
+is $t->lastname('Mehy2'), "Mehy2ar";
+is $t->fullname, "Mamod Mehyar";
+is $t->counter, 2;
+
+done_testing(207);


### PR DESCRIPTION
This new release is toward stabilizing and introduce new API

The new API mainly `to_perl_object` will provide a new way to call javascript objects from perl, where we will be able to get javascript objects and use them from perl the exact way they are used in javascript land.

Another issue to address is circular references, the current behavior is that we store perl subs in global hash to avoid being garbage collected while still needed by javascript, this will make it a memory hog once we try to push hundreds of perl functions, this version will introduce a fix for this problem by using duktape internal object finalizers, this solution will make things a little bit slower but much better with memory usage, there are some other ideas to fix this issue but at this stage object finalizes seems a good solution.
