### PR TITLE
fix undefined arguments not getting through

### DIFF
--- a/lib/JavaScript/Duktape.pm
+++ b/lib/JavaScript/Duktape.pm
@@ -392,7 +392,7 @@ sub to_perl {
     my $type = $self->get_type($index);
 
     if ($type == JavaScript::Duktape::DUK_TYPE_UNDEFINED){
-        return;
+        $ret = undef;
     }
 
     elsif ($type == JavaScript::Duktape::DUK_TYPE_STRING){

--- a/t/undefined.t
+++ b/t/undefined.t
@@ -1,0 +1,56 @@
+use strict;
+use warnings;
+use Data::Dumper;
+use lib './lib';
+use Test::More;
+use Data::Dumper;
+
+use FindBin qw($Bin);
+
+use_ok 'JavaScript::Duktape';
+
+subtest 'check undefined gets through to sub' => sub{
+    my $js = JavaScript::Duktape->new();
+
+    $js->set( foo=>sub{
+        is $_[0], undef;
+        is $_[1], 'bar';
+    });
+
+    $js->eval(qq~
+        foo( undefined, 'bar');
+    ~);
+};
+
+subtest 'check undefined return gets through from another sub' => sub{
+    my $js = JavaScript::Duktape->new();
+
+    $js->set( gen_undef=>sub{
+        return undef;
+    });
+    $js->set( foo=>sub{
+        is $_[0], undef;
+        is $_[1], 'bar';
+    });
+
+    $js->eval(qq~
+        foo( gen_undef(), 'bar');
+    ~);
+};
+
+subtest 'set to value to undefined and pass it to sub' => sub{
+    my $js = JavaScript::Duktape->new();
+
+    $js->set( myundef=>undef );
+
+    $js->set( foo=>sub{
+        is $_[0], undef;
+        is $_[1], 'bar';
+    });
+
+    $js->eval(qq~
+        foo( myundef, 'bar');
+    ~);
+};
+
+done_testing;


### PR DESCRIPTION
Hi Mamod, caught a bug (or enhancement, depending on how you look at it). Basically, the `undefined` values in JS were not being sent as arguments to the Perl subs through the `set` method. 

Take a look at the fix I've proposed.
